### PR TITLE
Add About page

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { Header } from '@/components/ui/header';
+
+export default function AboutPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
+        <section className="max-w-4xl mx-auto px-4 py-12">
+          <h1 className="text-3xl font-bold mb-4">About Argus</h1>
+          <p className="text-muted-foreground mb-4">
+            Argus analyzes MongoDB slow query logs and offers insights to help
+            optimize your database performance.
+          </p>
+          <p className="text-muted-foreground">
+            Built with Next.js and powered by AI, this project is currently in
+            beta. Feedback and contributions are welcome.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/components/ui/header.jsx
+++ b/components/ui/header.jsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Github } from 'lucide-react';
 import { ThemeToggle } from './theme-toggle';
+import { Button } from './button';
 
 export function Header() {
   return (
@@ -29,6 +30,9 @@ export function Header() {
           </Link>
           <div className="flex items-center gap-2">
             <ThemeToggle />
+            <Button variant="ghost" asChild>
+              <Link href="/about">About</Link>
+            </Button>
             <a
               href="https://github.com/ggagosh/argus"
               target="_blank"


### PR DESCRIPTION
## Summary
- add a simple About page under `app/about`
- link to the new page from the header

## Testing
- `npm run lint` *(fails: `next` not found)*